### PR TITLE
Update image to work with the current mariadb docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM mariadb:latest
 COPY galera.cnf /etc/mysql/conf.d/galera.cnf.template
 RUN chown -R mysql:mysql /etc/mysql/conf.d
 
-# Overwrite "mysqld" so we can intercept the
+# Overwrite "mariadb" so we can intercept the
 # call from the upstream entrypoint
-COPY galera.sh /usr/local/sbin/mysqld
+COPY galera.sh /usr/local/sbin/mariadb
 
 ENV MYSQL_ROOT_PASSWORD="mariadb" \
 	MYSQL_USER="mariadb" \

--- a/galera.sh
+++ b/galera.sh
@@ -23,7 +23,9 @@ if echo $* | grep -v -e '--skip-networking' | grep -v -e '--help'; then
     CLUSTER_MEMBERS=`getent hosts tasks.$SERVICE_NAME | grep -v $IP_ADDRESS | awk '{print $1}'`
     # Check we can see enough peers to form a Primary Component
     if [ `getent hosts tasks.$SERVICE_NAME | wc -l` -lt $(((${CLUSTER_NODES}+1)/2)) ]; then
-      echo "Can't see enough peers to form a cluster; restarting."
+      RESTART_DELAY=$(((1 + $RANDOM % 10)*6))
+      echo "Can't see enough peers to form a cluster; restarting in ${RESTART_DELAY} seconds."
+      sleep $RESTART_DELAY
       exit 1
     fi
     # If we're the first node then bootstrap the cluster


### PR DESCRIPTION
The current MariaDB image uses the `mariadbd` command instead of the "old" `mysqld` command.

In addition, I added a random delay (6-60 seconds) in the `galera.sh` script.
This is needed when creating a new docker service, else the peers would be trapped in an endless restart loop because there are not enough peers ready to create a cluster.